### PR TITLE
Use fiegn client to fetch favorites wines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
             <version>0.2.4-SNAPSHOT</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.wine.to.up</groupId>
+            <artifactId>user-service-api</artifactId>
+            <version>0.1.5-SNAPSHOT</version>
+        </dependency>
+
         <!-- Required: Spring-->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/profiles/catalog-service.yml
+++ b/profiles/catalog-service.yml
@@ -7,6 +7,9 @@ services:
       - 8080:8080
     environment:
       - S_POSTGRES_HOST=postgres
+      - S_POSTGRES_USER=postgres
+      - S_POSTGRES_PASSWORD=postgres
+      - S_POSTGRES_DB=postgres
       - S_KAFKA_BOOTSTRAP_HOST=kafka:9092
     depends_on:
       - kafka

--- a/src/main/java/com/wine/to/up/catalog/service/controller/WinePositionTrueController.java
+++ b/src/main/java/com/wine/to/up/catalog/service/controller/WinePositionTrueController.java
@@ -8,6 +8,7 @@ import com.wine.to.up.catalog.service.domain.response.WinePositionResponse;
 import com.wine.to.up.catalog.service.domain.response.WinePositionTrueResponse;
 import com.wine.to.up.catalog.service.domain.response.WineTrueResponse;
 import com.wine.to.up.catalog.service.utils.CompareChain;
+import com.wine.to.up.user.service.api.feign.FavoritesServiceClient;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +33,7 @@ public class WinePositionTrueController {
     private final WinePositionController winePositionController;
     private final ShopController shopController;
     private final WineTrueController wineTrueController;
+    private final FavoritesServiceClient favoritesServiceClient;
 
     @ApiOperation(value = "Get wine position by id",
             nickname = "getWinePositionById", notes = "",
@@ -46,8 +48,12 @@ public class WinePositionTrueController {
             nickname = "getFavouritesPositions",
             tags = {"wine-position-true-controller",})
     @GetMapping("/favourites")
-    public List<WinePositionTrueResponse> getFavourites(@Valid @RequestParam(required = true) List<String> favouritePosition) {
-        return favouritePosition.stream().map(this::getWineById).collect(Collectors.toList());
+    public List<WinePositionTrueResponse> getFavourites(
+            @RequestHeader("Authorization") String accessToken
+    ) {
+        List<String> ids = favoritesServiceClient.findUsersFavoritesIdList(accessToken);
+
+        return ids.stream().map(this::getWineById).collect(Collectors.toList());
     }
 
     @ApiOperation(value = "Get all wine positions",


### PR DESCRIPTION
Привет ребята
Я из фронтенд команды и нам бы очень не помешало вот это изменение в API. В прошлом семестре нам сказали что ну никак невозможно сделать такой эндпоинт, поэтому я решил взять все в свои руки (на самом деле было просто интересно).

Я проверил локально, все работает. Но честно говоря не очень понял как лучше обрабатывать ошибки в данном случае, а их может быть
1. Невалидный токен авторизации — вызов `findUsersFavoritesIdList` вернет NetworkError со статусом 401 Unauthorized. Но такое вряд ли возможно, потому что запрос завалиться еще на уровне API Gateway
2. Любая другая ошибка на стороне user-service вернет [RuntimeException("Unknown error")](https://github.com/microservices-course-itmo/user-service-api/blob/dev/src/main/java/com/wine/to/up/user/service/api/error/UserServiceErrorDecoder.java#L15)
3. User-service недоступен, в таком случае полагаю вернется NetworkError
4. id, который вернул user-service нет в вашей базе  — выбросится NoSuchElementException. Полагаю, в таком случае можно этот элемент просто пропустить, но вернуть все остальное.

Сейчас в любом из этих случаев на клиент возвращается просто 500, буду благодарен, если добавите обработку ошибок или укажете в каком направлении читать доку спринга, потому что как вернуть кастомную ошибку я не разобрался.


Помимо этого я пытался поднять все окружение в docker, и мне это даже удалось, но с очень большой болью. Думаю, это относится к любым сервисам, так что cc: @andrsuh 
1. Нигде не указано, что для выполнения команд `mvn` нужно передавать `-s settings.xml`, думаю стоит добавить это в ридми.
2. В user-service.yml не хватало некоторых переменных окружения, добавил в этом ПР
3. Плагин maven-dockerfile-plugin пытается пушить в Docker registry, которого локально не существует. Мне пришлось [поднять свой docker regsitry](https://docs.docker.com/registry/deploying/), но даже так мне не удалось настроить плагин, чтобы можно было спокойно из него делать пулл по названию image. Чтобы сильно в этом не увязнуть, я копировал id image в profile/catalog-service.yml. Точно не знаю как решить эту проблему, но тут возможно мне просто не хватает знаний как деплоится docker registry, может девопсы смогут помочь. Или вообще локально никуда не пушить, а просто брать собранный image. В любом случае понадобится отдельный yml файл для локального запуска docker-compose
4. При сборке в докер активный профайл [устанавливается "docker"](https://github.com/microservices-course-itmo/catalog-service/blob/dev/Dockerfile#L3). Поэтому [вот тут](https://github.com/microservices-course-itmo/catalog-service/blob/dev/src/main/resources/logback-spring.xml) logback пытается пушить логи в logstash, который локально не настроен, да и не должен быть я полагаю. Думаю можно сделать два Dockerfile (и соответственно два профайла) для сборки на CD и для сборки локально
5. Похожая проблема при использовании feign клиента user-service-api в докере. В артифактори он собран с тем же `doecker` профайлом. Для него хост API [указан](https://github.com/microservices-course-itmo/user-service-api/blob/dev/src/main/resources/application-user-service-api-docker.properties) как `user-service:8080`. Это прекрасно работает на CD, так как все контейнеры в одной сети, но локально мне пришлось поднимать reverse proxy с именем user-service в той же сети, чтобы это заработало. Аналогично предлагаю добавить отдельный Dockerfile и профайл для локальной разработки в докере.
6. При выполнении `mvn deploy`, который нужен, чтобы запушить имейдж в регистри, так же происходит попытка пушить jar в artifactory, но URL там [указан](https://github.com/microservices-course-itmo/catalog-service/blob/dev/pom.xml#L148) также для внутренней сети на CD. Для локальной разработки этот шаг наверное стоит совсем исключить.

Не очень понимаю каким образом ведется разработка на данный момент, видимо все стоит прямо на машинах, но в докере это делать без хаков невозможно. Было бы клево, если кто-нибудь из BE команд обратит на это внимание